### PR TITLE
Avoid detecting Force.com packages in `node_modules/`

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -1,0 +1,1 @@
+node_modules/


### PR DESCRIPTION
Fix for apps that have an npm/package.json dependency on **jsforce**, which would throw an error during `heroku force:src:push`:

> An error was encountered pushing changes to the scratch org. name: DeployFailed message: (1) JSforceTestPowerUser: Unknown user permission: CreatePackaging
