### PR TITLE
Fixing orgPreferences to match SFDX's expectations

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,11 +1,10 @@
 {
   "country": "US",
   "edition": "Developer",
-  "orgPreferences": {
-    "enabled": [
-      "S1DesktopEnabled"
-    ],
-    "disabled": []
+  "settings": {
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    }
   },
   "orgName": "Your Company",
   "adminEmail": "yourname@example.com"


### PR DESCRIPTION
Trying to create a scratch org for the first time, it is requesting this change:

```
$ sfdx force:org:create -s -f config/project-scratch-def.json
ERROR running force:org:create:  We've deprecated OrgPreferences. Update the scratch org definition file to replace OrgPreferences with their corresponding settings.

Replace the orgPreferences section:
{
    "orgPreferences": {
        "enabled": [
            "S1DesktopEnabled"
        ],
        "disabled": []
    }
}
With their updated settings:
{
    "settings": {
        "lightningExperienceSettings": {
            "enableS1DesktopEnabled": true
        }
    }
}
For more info on configuring settings in a scratch org definition file see: https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_scratch_orgs.htm.'
```

<img width="1252" alt="Screen Shot 2019-11-04 at 1 44 21 PM" src="https://user-images.githubusercontent.com/552279/68152730-da135780-ff09-11e9-8115-0b77accdd192.png">

This fix seems to take care of it, the scratch org get created successfully.

SFDX version: sfdx-cli/7.31.0-6a986f8be5 darwin-x64 node-v10.15.3