### PR TITLE
Updated deprecated OrgPreferences section with new settings section format

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,11 +1,10 @@
 {
   "country": "US",
   "edition": "Developer",
-  "orgPreferences": {
-    "enabled": [
-      "S1DesktopEnabled"
-    ],
-    "disabled": []
+  "settings": {
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    }
   },
   "orgName": "Your Company",
   "adminEmail": "yourname@example.com"


### PR DESCRIPTION
When following the "[Use a Sample Repo to Get Started](https://developer.salesforce.com/docs/atlas.en-us.224.0.sfdx_dev.meta/sfdx_dev/sfdx_dev_intro_sample_repo.htm)" tutorial, the configuration in the sample repo hasn't been kept up to date with the CLI, so everyone following the tutorial will get this error message:

`ERROR running force:org:create:  We've deprecated OrgPreferences. Update the scratch org definition file to replace OrgPreferences with their corresponding settings.`

Having an error in the tutorial's sample code will make it harder for people to get started, so I thought I'd just commit the fix that we're all going to have to make anyway, and save everyone else some time...