### PR TITLE
Updated deprecated OrgPreferences settings

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,11 +1,10 @@
 {
   "country": "US",
   "edition": "Developer",
-  "orgPreferences": {
-    "enabled": [
-      "S1DesktopEnabled"
-    ],
-    "disabled": []
+  "settings": {
+    "lightningExperienceSettings": {
+        "enableS1DesktopEnabled": true
+    }
   },
   "orgName": "Your Company",
   "adminEmail": "yourname@example.com"


### PR DESCRIPTION
While setting up scratch org using "sfdx force:org:create -s -f config/project-scratch-def.json", received following error and hence, creating this issue:
~~~
ERROR running force:org:create:  We've deprecated OrgPreferences. Update the scratch org definition file to replace OrgPreferences with their corresponding settings.

Replace the orgPreferences section:
{
    "orgPreferences": {
        "enabled": [
            "S1DesktopEnabled"
        ],
        "disabled": []
    }
}
With their updated settings:
{
    "settings": {
        "lightningExperienceSettings": {
            "enableS1DesktopEnabled": true
        }
    }
}
For more info on configuring settings in a scratch org definition file see: https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_scratch_orgs.htm.'
~~~