### PR TITLE
prior configuration mode was deprecated; need to set a default as true to be able to push

### DIFF
--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,12 +1,7 @@
 {
   "country": "US",
   "edition": "Developer",
-  "orgPreferences": {
-    "enabled": [
-      "S1DesktopEnabled"
-    ],
-    "disabled": []
-  },
+  "settings": { "lightningExperienceSettings": { "enableS1DesktopEnabled": true } },
   "orgName": "Your Company",
   "adminEmail": "yourname@example.com"
 }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -1,7 +1,8 @@
 {
   "packageDirectories": [
     {
-      "path": "force-app"
+      "path": "force-app",
+      "default": true
     }
   ],
   "namespace": "",


### PR DESCRIPTION
 We've deprecated OrgPreferences. Update the scratch org definition file to replace OrgPreferences with their corresponding settings.

Replace the orgPreferences section:
{
    "orgPreferences": {
        "enabled": [
            "S1DesktopEnabled"
        ],
        "disabled": []
    }
}
With their updated settings:
{
    "settings": {
        "lightningExperienceSettings": {
            "enableS1DesktopEnabled": true
        }
    }
}
For more info on configuring settings in a scratch org definition file see: https://developer.salesforce.com/docs/atlas.en-us.sfdx_dev.meta/sfdx_dev/sfdx_dev_scratch_orgs.htm.'





For the second file >

$ sfdx force:source:push
ERROR running force:source:push:  In sfdx-project.json, be sure to specify which
 package directory (path) is the default. Example: [{ "path": "packageDirectory1
", "default": true }, { "path": "packageDirectory2" }]
